### PR TITLE
Set flag to enable -fPic (set position independent code)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 platform:
     - x64
 
-cache:
-    - C:\Users\appveyor\.esy\3_\i
-    - C:\Users\appveyor\.esy\source-tarballs
+# cache:
+#     - C:\Users\appveyor\.esy\3_\i
+#     - C:\Users\appveyor\.esy\source-tarballs
 
 install:
     # The x64 is required as a workaround for esy/esy#412

--- a/esy/configure.sh
+++ b/esy/configure.sh
@@ -1,5 +1,5 @@
 mkdir -p _build
 cd _build
 
-cmake -G "Unix Makefiles" ../ -DCMAKE_INSTALL_PREFIX=$cur__install -DCMAKE_DISABLE_FIND_PACKAGE_BZIP2=TRUE
+cmake -G "Unix Makefiles" ../ -DCMAKE_INSTALL_PREFIX=$cur__install -DCMAKE_DISABLE_FIND_PACKAGE_BZIP2=TRUE -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE
 


### PR DESCRIPTION
We need to set the `-fPic` flag for Linux x64, otherwise we'll hit issues with `ocamlopt`: 
```
relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
```

This is documented under the 'shared' flag for `ocamlopt`:
https://caml.inria.fr/pub/docs/manual-ocaml/native.html