### PR TITLE
Bugfix: esy-freetype2 fails to build if mingw cross-compiler is on non-Windows platform

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -11,5 +11,3 @@ steps:
     continueOnError: true
   - script: esy install
   - script: esy build
-  - script: esy b ./esy/test.sh
-    displayName: "Test compilation"

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -11,3 +11,5 @@ steps:
     continueOnError: true
   - script: esy install
   - script: esy build
+  - script: esy b ./esy/test.sh
+    displayName: "Test compilation"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "esy": {
     "build": [
         ["bash", "-c", "#{os == 'windows' ? './esy/configure-windows.sh' : './esy/configure.sh'}"],
-        ["./esy/build.sh"],
-        ["./esy/test.sh"]
+        ["./esy/build.sh"]
     ],
     "buildsInSource": "_build",
     "exportedEnv": {


### PR DESCRIPTION
__Issue:__ If there is an `x86_64-w64-mingw32-gcc` in the PATH, our test script assumes that we're on Windows and tries to build a test app in Windows style.

__Fix:__ We shouldn't build this 'test app' as part of the main build - the test isn't useful it causes more problems than it solves.