### PR TITLE
fix(windows): Disable build on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "esy": {
     "build": [
-        ["bash", "-c", "#{os == 'windows' ? 'skipping freetype configure on windows' : './esy/configure.sh'}"],
-        ["bash", "-c", "#{os == 'windows' ? 'skipping freetype build on windows' : './esy/build.sh'}"],
+        ["bash", "-c", "#{os == 'windows' ? 'echo \"skipping-configure\"' : './esy/configure.sh'}"],
+        ["bash", "-c", "#{os == 'windows' ? 'echo \"skipping-build\"' : './esy/build.sh'}"]
     ],
     "buildsInSource": "_build",
     "exportedEnv": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "esy": {
     "build": [
-        ["bash", "-c", "#{os == 'windows' ? './esy/configure-windows.sh' : './esy/configure.sh'}"],
-        ["./esy/build.sh"]
+        ["bash", "-c", "#{os == 'windows' ? 'skipping freetype configure on windows' : './esy/configure.sh'}"],
+        ["bash", "-c", "#{os == 'windows' ? 'skipping freetype build on windows' : './esy/build.sh'}"],
     ],
     "buildsInSource": "_build",
     "exportedEnv": {


### PR DESCRIPTION
The same `cmake` issue affected `esy-harfbuzz` is impacting `esy-freetype2`:https://github.com/revery-ui/esy-harfbuzz/commit/380833bb511ace7b700825fbbe51023ef7ffb6fb

Since we switched to skia for Revery, we no longer need the Windows build (skia uses the DirectWrite APIs) - so we can disable the freetype build on windows as a workaround.

